### PR TITLE
[DEV] Milestone Challenge Linking

### DIFF
--- a/src/actions/projects.js
+++ b/src/actions/projects.js
@@ -1,9 +1,10 @@
 import {
   LOAD_PROJECT_BILLING_ACCOUNT,
   LOAD_CHALLENGE_MEMBERS_SUCCESS,
-  LOAD_PROJECT_DETAILS
+  LOAD_PROJECT_DETAILS,
+  LOAD_PROJECT_PHASES
 } from '../config/constants'
-import { fetchProjectById, fetchBillingAccount } from '../services/projects'
+import { fetchProjectById, fetchBillingAccount, fetchProjectPhases } from '../services/projects'
 
 /**
  * Loads project details
@@ -25,6 +26,12 @@ export function loadProject (projectId) {
         dispatch({
           type: LOAD_PROJECT_BILLING_ACCOUNT,
           payload: fetchBillingAccount(projectId)
+        })
+
+        // Loads project phases
+        dispatch({
+          type: LOAD_PROJECT_PHASES,
+          payload: fetchProjectPhases(projectId)
         })
 
         return project

--- a/src/components/Buttons/PrimaryButton/PrimaryButton.module.scss
+++ b/src/components/Buttons/PrimaryButton/PrimaryButton.module.scss
@@ -57,6 +57,15 @@
     }
   }
 
+  &.successDark {
+    @include roboto-bold;
+    background-color: $tc-green-50;
+    &:disabled {
+      cursor: default;
+      background-color: $inactive;
+    }
+  }
+
   /* this style just visually simulates the disable status of the button */
   &.disabled {
     cursor: default;

--- a/src/components/ChallengeEditor/ChallengeViewTabs/index.js
+++ b/src/components/ChallengeEditor/ChallengeViewTabs/index.js
@@ -41,7 +41,8 @@ const ChallengeViewTabs = ({
   enableEdit,
   onLaunchChallenge,
   cancelChallenge,
-  onCloseTask
+  onCloseTask,
+  projectPhases
 }) => {
   const [selectedTab, setSelectedTab] = useState(0)
 
@@ -203,6 +204,7 @@ const ChallengeViewTabs = ({
           enableEdit={enableEdit}
           onLaunchChallenge={onLaunchChallenge}
           onCloseTask={onCloseTask}
+          projectPhases={projectPhases}
         />
       )}
       {selectedTab === 1 && (
@@ -238,7 +240,8 @@ ChallengeViewTabs.propTypes = {
   enableEdit: PropTypes.bool,
   onLaunchChallenge: PropTypes.func,
   cancelChallenge: PropTypes.func.isRequired,
-  onCloseTask: PropTypes.func
+  onCloseTask: PropTypes.func,
+  projectPhases: PropTypes.arrayOf(PropTypes.object)
 }
 
 export default ChallengeViewTabs

--- a/src/components/ChallengeEditor/Milestone-Field/Milestone-Field.module.scss
+++ b/src/components/ChallengeEditor/Milestone-Field/Milestone-Field.module.scss
@@ -1,0 +1,61 @@
+@import "../../../styles/includes";
+
+.row {
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: row;
+  margin: 30px 30px 0 30px;
+  align-content: space-between;
+  justify-content: flex-start;
+
+  .field {
+    @include upto-sm {
+      display: block;
+      padding-bottom: 10px;
+    }
+
+    label {
+      @include roboto-bold();
+
+      font-size: 16px;
+      line-height: 19px;
+      font-weight: 500;
+      color: $tc-gray-80;
+    }
+
+    &.col1 {
+      max-width: 185px;
+      min-width: 185px;
+      margin-right: 14px;
+      white-space: nowrap;
+      display: flex;
+      align-items: center;
+      flex-grow: 1;
+
+      span {
+        color: $tc-red;
+      }
+    }
+
+    &.col2.error {
+      color: $tc-red;
+      margin-top: -25px;
+    }
+    &.col2 {
+      align-self: flex-end;
+      width: 80%;
+      margin-bottom: auto;
+      margin-top: auto;
+      display: flex;
+      flex-direction: row;
+      max-width: 600px;
+      min-width: 600px;
+    }
+
+    &.manageLink {
+      margin: 2px 12px;
+      text-decoration: none;
+      font-size: 12px;
+    }
+  }
+}

--- a/src/components/ChallengeEditor/Milestone-Field/index.js
+++ b/src/components/ChallengeEditor/Milestone-Field/index.js
@@ -1,0 +1,55 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import _ from 'lodash'
+import Select from '../../Select'
+import cn from 'classnames'
+import styles from './Milestone-Field.module.scss'
+import { CONNECT_APP_URL } from '../../../config/constants'
+import PrimaryButton from '../../Buttons/PrimaryButton'
+
+const MilestoneField = ({ milestones, onUpdateSelect, disabled, projectId, selectedMilestoneId }) => {
+  const options = milestones.map(type => ({ label: type.name, value: type.id }))
+  const selectedIndex = selectedMilestoneId && _.findIndex(milestones, milestone => milestone.id === selectedMilestoneId)
+  const selectedOption = selectedIndex !== -1 && options[selectedIndex]
+  return (
+    <>
+      <div className={styles.row}>
+        <div className={cn(styles.field, styles.col1)}>
+          <label htmlFor='type'>Choose Milestone :</label>
+        </div>
+        <div className={cn(styles.field, styles.col2, { [styles.disabled]: disabled })}>
+          <Select
+            value={selectedOption}
+            name='milestone'
+            options={options}
+            placeholder='Milestone Name'
+            isClearable
+            onChange={(e) => onUpdateSelect(_.get(e, 'value', -1), false, 'milestoneId')}
+            isDisabled={disabled}
+          />
+        </div>
+        <a className={cn(styles.field, styles.manageLink)} href={`${CONNECT_APP_URL}/projects/${projectId}`} target='_blank'
+          rel='noopener noreferrer'>
+          <PrimaryButton type='successDark' text='MANAGE MILESTONES' />
+        </a>
+      </div>
+    </>
+  )
+}
+
+MilestoneField.defaultProps = {
+  milestones: [],
+  disabled: false
+}
+
+MilestoneField.propTypes = {
+  // currentType: PropTypes.string.isRequired,
+  track: PropTypes.string,
+  milestones: PropTypes.arrayOf(PropTypes.shape()),
+  onUpdateSelect: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+  projectId: PropTypes.number,
+  selectedMilestoneId: PropTypes.number
+}
+
+export default MilestoneField

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -52,6 +52,11 @@ export const LOAD_PROJECT_BILLING_ACCOUNT_PENDING = 'LOAD_PROJECT_BILLING_ACCOUN
 export const LOAD_PROJECT_BILLING_ACCOUNT_FAILURE = 'LOAD_PROJECT_BILLING_ACCOUNT_FAILURE'
 export const LOAD_PROJECT_BILLING_ACCOUNT_SUCCESS = 'LOAD_PROJECT_BILLING_ACCOUNT_SUCCESS'
 
+export const LOAD_PROJECT_PHASES = 'LOAD_PROJECT_PHASES'
+export const LOAD_PROJECT_PHASES_PENDING = 'LOAD_PROJECT_PHASES_PENDING'
+export const LOAD_PROJECT_PHASES_FAILURE = 'LOAD_PROJECT_PHASES_FAILURE'
+export const LOAD_PROJECT_PHASES_SUCCESS = 'LOAD_PROJECT_PHASES_SUCCESS'
+
 export const SET_ACTIVE_PROJECT = 'SET_ACTIVE_PROJECT'
 
 export const LOAD_USER_SUCCESS = 'LOAD_USER_SUCCESS'
@@ -248,3 +253,23 @@ export const CANCEL_REASONS = [
   'Cancelled - Requirements Infeasible',
   'Cancelled - Zero Registrations'
 ]
+
+/**
+ * Milestone product details
+ */
+export const GENERIC_PROJECT_MILESTONE_PRODUCT_TYPE = 'generic-product'
+export const GENERIC_PROJECT_MILESTONE_PRODUCT_NAME = 'Generic Product'
+export const PHASE_PRODUCT_TEMPLATE_ID = 67
+export const PHASE_PRODUCT_CHALLENGE_ID_FIELD = 'details.challenge'
+
+/*
+ *  Possible statuses of project milestones
+ */
+export const MILESTONE_STATUS = {
+  UNPLANNED: 'in_review',
+  PLANNED: 'reviewed',
+  ACTIVE: 'active',
+  BLOCKED: 'paused',
+  COMPLETED: 'completed',
+  CANCELLED: 'cancelled'
+}

--- a/src/containers/ChallengeEditor/index.js
+++ b/src/containers/ChallengeEditor/index.js
@@ -328,7 +328,9 @@ class ChallengeEditor extends Component {
       createChallenge,
       replaceResourceInRole,
       deleteChallenge,
-      loggedInUser
+      loggedInUser,
+      projectPhases,
+      isProjectPhasesLoading
       // members
     } = this.props
     const {
@@ -340,7 +342,7 @@ class ChallengeEditor extends Component {
       suceessMessage,
       challengeDetails
     } = this.state
-    if (isProjectLoading || isLoading) return <Loader />
+    if (isProjectLoading || isLoading || isProjectPhasesLoading) return <Loader />
     const challengeId = _.get(match.params, 'challengeId', null)
     if (challengeId && (!challengeDetails || !challengeDetails.id)) {
       return <Loader />
@@ -421,6 +423,7 @@ class ChallengeEditor extends Component {
               createChallenge={createChallenge}
               replaceResourceInRole={replaceResourceInRole}
               partiallyUpdateChallengeDetails={partiallyUpdateChallengeDetails}
+              projectPhases={projectPhases}
             />
           )}
         />
@@ -458,6 +461,7 @@ class ChallengeEditor extends Component {
                 }
                 deleteChallenge={deleteChallenge}
                 loggedInUser={loggedInUser}
+                projectPhases={projectPhases}
               />
             )}
           />
@@ -471,6 +475,7 @@ class ChallengeEditor extends Component {
               isBillingAccountExpired={isBillingAccountExpired}
               metadata={metadata}
               projectDetail={projectDetail}
+              projectPhases={projectPhases}
               challengeSubmissions={challengeSubmissions}
               challenge={challengeDetails}
               cancelChallenge={this.cancelChallenge}
@@ -534,7 +539,9 @@ ChallengeEditor.propTypes = {
   createChallenge: PropTypes.func.isRequired,
   deleteChallenge: PropTypes.func.isRequired,
   replaceResourceInRole: PropTypes.func,
-  loadProject: PropTypes.func
+  loadProject: PropTypes.func,
+  projectPhases: PropTypes.arrayOf(PropTypes.object),
+  isProjectPhasesLoading: PropTypes.bool
   // members: PropTypes.arrayOf(PropTypes.shape())
 }
 
@@ -556,6 +563,8 @@ const mapStateToProps = ({
   challengeDetails,
   hasProjectAccess: projects.hasProjectAccess,
   projectDetail: projects.projectDetail,
+  projectPhases: projects.phases,
+  isProjectPhasesLoading: projects.isPhasesLoading,
   challengeResources,
   challengeSubmissions,
   metadata,

--- a/src/reducers/projects.js
+++ b/src/reducers/projects.js
@@ -8,14 +8,19 @@ import {
   LOAD_PROJECT_BILLING_ACCOUNT_FAILURE,
   LOAD_PROJECT_DETAILS_FAILURE,
   LOAD_PROJECT_DETAILS_PENDING,
-  LOAD_PROJECT_DETAILS_SUCCESS
+  LOAD_PROJECT_DETAILS_SUCCESS,
+  LOAD_PROJECT_PHASES_FAILURE,
+  LOAD_PROJECT_PHASES_PENDING,
+  LOAD_PROJECT_PHASES_SUCCESS
 } from '../config/constants'
 
 const initialState = {
   isLoading: false,
   projectDetail: {},
   isBillingAccountExpired: false,
-  isBillingAccountLoading: false
+  isBillingAccountLoading: false,
+  isPhasesLoading: false,
+  phases: []
 }
 
 export default function (state = initialState, action) {
@@ -50,6 +55,23 @@ export default function (state = initialState, action) {
         ...state,
         isBillingAccountLoading: false,
         isBillingAccountExpired: false
+      }
+    case LOAD_PROJECT_PHASES_PENDING:
+      return {
+        ...state,
+        phases: [],
+        isPhasesLoading: true
+      }
+    case LOAD_PROJECT_PHASES_SUCCESS:
+      return {
+        ...state,
+        phases: action.payload,
+        isPhasesLoading: false
+      }
+    case LOAD_PROJECT_PHASES_FAILURE:
+      return {
+        ...state,
+        isPhasesLoading: false
       }
     default:
       return state

--- a/src/services/projects.js
+++ b/src/services/projects.js
@@ -1,6 +1,11 @@
 import _ from 'lodash'
 import { axiosInstance } from './axiosWithAuth'
 import * as queryString from 'query-string'
+import {
+  GENERIC_PROJECT_MILESTONE_PRODUCT_NAME,
+  GENERIC_PROJECT_MILESTONE_PRODUCT_TYPE, PHASE_PRODUCT_CHALLENGE_ID_FIELD,
+  PHASE_PRODUCT_TEMPLATE_ID
+} from '../config/constants'
 const { PROJECT_API_URL } = process.env
 
 /**
@@ -36,4 +41,76 @@ export async function fetchMemberProjects (filters) {
 export async function fetchProjectById (id) {
   const response = await axiosInstance.get(`${PROJECT_API_URL}/${id}`)
   return _.get(response, 'data')
+}
+
+/**
+ * Api request for fetching project phases
+ * @param id Project id
+ * @returns {Promise<*>}
+ */
+export async function fetchProjectPhases (id) {
+  const response = await axiosInstance.get(`${PROJECT_API_URL}/${id}/phases`, {
+    params: {
+      fields: 'id,name,products,status'
+    }
+  })
+  return _.get(response, 'data')
+}
+
+/**
+ * Save challengeId as Phase product detail
+ * @param projectId Project id
+ * @param phaseId phase id
+ * @param challengeId challengeId
+ * @param isNewChallenge indicated if it's for newly created challenge
+ * @returns {Promise<*>}
+ */
+export async function saveChallengeAsPhaseProduct (projectId, phaseId, challengeId, isNewChallenge = false) {
+  // Remove from other phase, if it's called for update
+  if (!isNewChallenge) {
+    await removeChallengeFromPhaseProduct(projectId, challengeId)
+  }
+  const payload = {
+    name: GENERIC_PROJECT_MILESTONE_PRODUCT_NAME,
+    type: GENERIC_PROJECT_MILESTONE_PRODUCT_TYPE,
+    templateId: PHASE_PRODUCT_TEMPLATE_ID,
+    // The api requires actualPrice and estimatedPrice to be set as positive numbers
+    // It doesn't update elasticsearch index if the values are null
+    actualPrice: 1,
+    estimatedPrice: 1
+  }
+
+  return axiosInstance.post(`${PROJECT_API_URL}/${projectId}/phases/${phaseId}/products`,
+    _.set(payload, PHASE_PRODUCT_CHALLENGE_ID_FIELD, challengeId)
+  )
+}
+
+/**
+ * Removes challenge from phase product it belongs to
+ * @param projectId Project id
+ * @param challengeId challengeId
+ * @returns {Promise<*>}
+ */
+export async function removeChallengeFromPhaseProduct (projectId, challengeId) {
+  // first fetch products again to make sure we have the latest products
+  const phases = await fetchProjectPhases(projectId)
+  let selectedMilestoneProduct
+  _.some(phases,
+    phase => {
+      const product = _.find(_.get(phase, 'products', []),
+        product => _.get(product, PHASE_PRODUCT_CHALLENGE_ID_FIELD) === challengeId
+      )
+      if (product) {
+        selectedMilestoneProduct = {
+          phaseId: phase.id,
+          productId: product.id
+        }
+        return true
+      }
+    })
+
+  if (selectedMilestoneProduct) {
+    // If its the only challenge in product and product doesn't contain any other detail just delete it
+    return axiosInstance.delete(`${PROJECT_API_URL}/${projectId}/phases/${selectedMilestoneProduct.phaseId}/products/${selectedMilestoneProduct.productId}`)
+  }
 }

--- a/src/styles/_colors.scss
+++ b/src/styles/_colors.scss
@@ -42,6 +42,7 @@ $tc-blue-40: #16679A;
 $tc-green-20: #43D7B0;
 $tc-green-30: #60C602;
 $tc-green-40: #35AC35;
+$tc-green-50: #127D60;
 
 $tc-red: #BE405E;
 


### PR DESCRIPTION
This is part of Milestone Management project/initiative, the goal of the project is to improve the communication and project progress UX with the customers.

As part of the scope, is to allow linking challenges with milestones. 

In this PR :
- Added Milestone drop down when create a challenge
- Adding Milestone label in the challenge page if it is linked to a milestone
- Allow editing a milestone for an existing challenge (either change or add new link)
- When update the linking, it will delete the existing link, and add new one.
- The app is using product.details.challenge string in constant file as key for the dynamic field that store the challenge id in the milestone/phase. 

Bug
- [ ] Need to fix projects-api to delete the product phase from ES, when it is deleted from Database