### PR TITLE
bug fix for  #1388

### DIFF
--- a/src/components/PhaseInput/index.js
+++ b/src/components/PhaseInput/index.js
@@ -54,7 +54,7 @@ const PhaseInput = ({ onUpdatePhase, phase, readOnly, phaseIndex }) => {
           <span className={styles.title}>Start Date:</span>
           <div className={styles.dayPicker}>
             {
-              readOnly || !isStartTimeActive ? (
+              readOnly ? (
                 <span className={styles.readOnlyValue}>{moment(startDate).format(dateFormat)}</span>
               )
                 : (


### PR DESCRIPTION
The jsx condition is forcing date to be rendered in a span when selected date is in the past. Change condition to "readOnly" instead of "readOnly || !isStartTimeActive"