### PR TITLE
PM-898 Fix reset filter in Challenge listing

### DIFF
--- a/src/components/ChallengesComponent/ChallengeList/index.js
+++ b/src/components/ChallengesComponent/ChallengeList/index.js
@@ -303,6 +303,7 @@ class ChallengeList extends Component {
     }
 
     let projectId = dashboard ? filterProjectOption : activeProjectId
+    console.log('project id', projectId)
     loadChallengesByPage(
       page,
       projectId,
@@ -341,14 +342,13 @@ class ChallengeList extends Component {
     const {
       activeProjectId,
       dashboard,
-      filterProjectOption,
       selfService,
       loadChallengesByPage
     } = this.props
 
     this.setState(_.cloneDeep(defaultSearchParam))
 
-    let projectId = dashboard ? filterProjectOption : activeProjectId
+    let projectId = dashboard ? undefined : activeProjectId
 
     loadChallengesByPage(
       1,

--- a/src/components/ChallengesComponent/ChallengeList/index.js
+++ b/src/components/ChallengesComponent/ChallengeList/index.js
@@ -303,7 +303,6 @@ class ChallengeList extends Component {
     }
 
     let projectId = dashboard ? filterProjectOption : activeProjectId
-    console.log('project id', projectId)
     loadChallengesByPage(
       page,
       projectId,


### PR DESCRIPTION
### What's in this PR?

The challenge list fetch endpoint was being passed with the previous project Id selected. In case of reset Filter, projectId should be changed to undefined(?)